### PR TITLE
Update to use Code instead of UUID

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -108,7 +108,7 @@ app.post('/api/search', async (req, res) => {
     const pool = pools[i];
     try {
       let sql = `SELECT hc.certificateNumber AS CertificateNumber, hc.code AS Code, p.name AS PersonName,
-                 ${i + 1} AS dbIndex, hc.status, hc.uuid AS UUID, p.id AS PersonId
+                 ${i + 1} AS dbIndex, hc.status, p.id AS PersonId
                  FROM HC_HealthCertificate hc
                  LEFT JOIN HC_Person p ON hc.Person = p.id
                  LEFT JOIN HC_Facility f ON hc.Facility = f.id
@@ -146,9 +146,7 @@ app.post('/api/search', async (req, res) => {
         results.push({
           ...row,
           printUrl: dbConfigs[i].printUrl,
-          editUrl: dbConfigs[i].editUrl,
-          UUID: row.UUID,
-          PersonId: row.PersonId
+          editUrl: dbConfigs[i].editUrl
         })
       );
     } catch (err) {

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -50,7 +50,7 @@ function renderPage(page) {
     const tr = document.createElement('tr');
     tr.dataset.index = r.dbIndex;
     const statusCell = `<span class="${statusClass(r.status)}">${statusText(r.status)}</span>`;
-    const link = `${r.printUrl}${r.UUID}`;
+    const link = `${r.printUrl}${r.Code}`;
     tr.innerHTML = `<td><a href="${link}" target="_blank"><pre class="codebox">${r.CertificateNumber}</pre></a></td><td>${r.PersonName}</td><td>${r.dbIndex}</td><td>${statusCell}</td><td>${createActionButtons(r, r.dbIndex)}</td>`;
     tbody.appendChild(tr);
   });


### PR DESCRIPTION
## Summary
- switch search SQL from selecting `uuid` to `code`
- stop sending UUID to the frontend
- build print links using `Code`

## Testing
- `node --check backend/app.js`
- `node --check public/scripts/main.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688c0acbfe648331b1fc9d946ec46791