### PR TITLE
Add button to open certificate creation link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -104,6 +104,9 @@
         <div id="pagination"></div>
       </div>
       <div class="d-flex justify-content-end mt-2">
+        <a id="addBtn" class="btn btn-success ms-auto" target="_blank">
+          <i class="bi bi-plus-circle"></i> إضافة شهادة
+        </a>
         <button class="btn btn-success ms-2" id="activateAll"><i class="bi bi-play-fill"></i> تشغيل الكل</button>
         <button class="btn btn-warning ms-2" id="deactivateAll"><i class="bi bi-pause-fill"></i> إيقاف الكل</button>
         <button class="btn btn-danger" id="flagAll"><i class="bi bi-exclamation-triangle-fill"></i> وضع نصاب على الكل</button>

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -168,7 +168,19 @@ function clearSearch() {
 }
 
 // enable Bootstrap tooltips
+async function setAddLink() {
+  try {
+    const res = await fetch('/api/addUrl');
+    const { url } = await res.json();
+    const btn = document.getElementById('addBtn');
+    if (btn) btn.href = url;
+  } catch (err) {
+    console.error('Failed to fetch add URL', err);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
   tooltipTriggerList.map(t => new bootstrap.Tooltip(t));
+  setAddLink();
 });


### PR DESCRIPTION
## Summary
- add `Add Certificate` button to results controls
- fetch `/api/addUrl` on page load and update new button link

## Testing
- `node -c public/scripts/main.js`
- `npm start` *(fails: ECONNREFUSED for DB connection)*

------
https://chatgpt.com/codex/tasks/task_e_688c125fee188331b257cb0d754b2a30