### PR TITLE
Add button to open certificate creation link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,9 +35,14 @@
 <body>
   <div class="container py-4">
     <h1 class="mb-4 text-center">البحث في الشهادات الصحية</h1>
-    <button class="btn btn-secondary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#advanced" aria-expanded="false">
-      <i class="bi bi-funnel"></i> بحث متقدم
-    </button>
+    <div class="d-flex justify-content-end gap-2 mb-3">
+      <a id="addBtn" class="btn btn-success" target="_blank">
+        <i class="bi bi-plus-circle"></i> إضافة شهادة
+      </a>
+      <button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#advanced" aria-expanded="false">
+        <i class="bi bi-funnel"></i> بحث متقدم
+      </button>
+    </div>
     <div class="collapse" id="advanced">
       <div class="card card-body">
         <h5 class="mb-3">🔍 البحث المتقدم</h5>

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -168,7 +168,19 @@ function clearSearch() {
 }
 
 // enable Bootstrap tooltips
+async function setAddLink() {
+  try {
+    const res = await fetch('/api/addUrl');
+    const { url } = await res.json();
+    const btn = document.getElementById('addBtn');
+    if (btn) btn.href = url;
+  } catch (err) {
+    console.error('Failed to fetch add URL', err);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
   tooltipTriggerList.map(t => new bootstrap.Tooltip(t));
+  setAddLink();
 });


### PR DESCRIPTION
## Summary
- add `Add Certificate` button beside advanced search
- fetch `/api/addUrl` on page load and update the new button link

## Testing
- `node -c public/scripts/main.js`
- `npm start` *(fails: ECONNREFUSED for DB connection)*

------
https://chatgpt.com/codex/tasks/task_e_688c125fee188331b257cb0d754b2a30