### PR TITLE
Add broader search criteria

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -121,8 +121,25 @@ app.post('/api/search', async (req, res) => {
                  WHERE 1=1`;
       const params = [];
       if (query) {
-        sql += ' AND (hc.certificateNumber LIKE ? OR hc.code LIKE ? OR f.FacilityNumber LIKE ? OR f.licenseNumber LIKE ?)';
-        params.push(`%${query}%`, `%${query}%`, `%${query}%`, `%${query}%`);
+        sql +=
+          ' AND (hc.certificateNumber LIKE ?' +
+          ' OR hc.code LIKE ?' +
+          ' OR f.FacilityNumber LIKE ?' +
+          ' OR f.licenseNumber LIKE ?' +
+          ' OR p.NationalIdentificationNo LIKE ?' +
+          ' OR p.name LIKE ?' +
+          ' OR s.name LIKE ?' +
+          ' OR f.FacilityName LIKE ?)';
+        params.push(
+          `%${query}%`,
+          `%${query}%`,
+          `%${query}%`,
+          `%${query}%`,
+          `%${query}%`,
+          `%${query}%`,
+          `%${query}%`,
+          `%${query}%`
+        );
       }
       if (supplier) {
         sql += ' AND hc.Supplier = ?';

--- a/public/index.html
+++ b/public/index.html
@@ -78,7 +78,7 @@
       </div>
     </div>
     <div class="mb-3">
-      <input type="text" id="mainQuery" class="form-control" placeholder="رقم الشهادة أو الكود أو رقم المنشأة أو الرخصة">
+      <input type="text" id="mainQuery" class="form-control" placeholder="رقم الشهادة أو الكود أو رقم المنشأة أو الرخصة أو رقم الهوية أو اسم الشخص أو اسم المورد أو اسم المنشأة">
     </div>
     <div class="mt-3 d-flex align-items-center gap-2">
       <button class="btn btn-primary" id="searchBtn"><i class="bi bi-search"></i> بحث</button>


### PR DESCRIPTION
## Summary
- extend the `/api/search` endpoint to search by National ID, person name, supplier name and facility name
- update the main search placeholder to reflect new options

## Testing
- `npm test` *(fails: Missing script)*
- `node backend/app.js` *(fails to connect to DB as expected)*

------
https://chatgpt.com/codex/tasks/task_e_688c22983f8c833182e8531ac3a61bdd