### PR TITLE
Include view parameter in certificate links

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -50,9 +50,8 @@ function renderPage(page) {
   pageData.forEach(r => {
     const tr = document.createElement('tr');
     tr.dataset.index = r.dbIndex;
-    r.suffixurl = '&view=1';
     const statusCell = `<span class="${statusClass(r.status)}">${statusText(r.status)}</span>`;
-    const link = `${r.printUrl}${r.Code}`;
+    const link = `${r.printUrl}${r.Code}&view=4`;
     tr.innerHTML = `<td><a href="${link}" target="_blank"><pre class="codebox">${r.CertificateNumber}</pre></a></td><td>${r.PersonName}</td><td>${r.SupplierName || ''}</td><td>${r.dbIndex}</td><td>${statusCell}</td><td>${createActionButtons(r, r.dbIndex)}</td>`;
     tbody.appendChild(tr);
   });


### PR DESCRIPTION
## Summary
- Ensure certificate links open with `view=4` by appending the parameter directly to the URL.
- Remove unused `suffixurl` variable from `renderPage`.

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68addc955eac8331aa6acd48db73df8c