### PR TITLE
Expose document_id and add Riyadh print link

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -113,7 +113,7 @@ app.post('/api/search', async (req, res) => {
     const pool = pools[i];
     try {
       let sql = `SELECT hc.certificateNumber AS CertificateNumber, hc.code AS Code, p.name AS PersonName,
-                 s.name AS SupplierName, ${i + 1} AS dbIndex, hc.status, p.id AS PersonId
+                 s.name AS SupplierName, ${i + 1} AS dbIndex, hc.status, hc.document_id AS document_id, p.id AS PersonId
                  FROM HC_HealthCertificate hc
                  LEFT JOIN HC_Person p ON hc.Person = p.id
                  LEFT JOIN HC_Facility f ON hc.Facility = f.id
@@ -178,6 +178,7 @@ app.post('/api/search', async (req, res) => {
       rows.forEach(row =>
         results.push({
           ...row,
+          document_id: row.document_id,
           printUrl: dbConfigs[i].printUrl,
           editUrl: dbConfigs[i].editUrl
         })

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -51,8 +51,14 @@ function renderPage(page) {
     const tr = document.createElement('tr');
     tr.dataset.index = r.dbIndex;
     const statusCell = `<span class="${statusClass(r.status)}">${statusText(r.status)}</span>`;
-    const link = `${r.printUrl}${r.Code}&view=4`;
-    tr.innerHTML = `<td><a href="${link}" target="_blank"><pre class="codebox">${r.CertificateNumber}</pre></a></td><td>${r.PersonName}</td><td>${r.SupplierName || ''}</td><td>${r.dbIndex}</td><td>${statusCell}</td><td>${createActionButtons(r, r.dbIndex)}</td>`;
+    let defaultLink = `${r.printUrl}${r.Code}`;
+    if (!defaultLink.includes('view=')) defaultLink += '&view=1';
+    let links = `<a href="${defaultLink}" target="_blank"><pre class="codebox">${r.CertificateNumber}</pre></a>`;
+    if (r.document_id == 4) {
+      const riyadhLink = `${r.printUrl}${r.Code}&view=4`;
+      links += ` <a href="${riyadhLink}" target="_blank" title="طباعة أمانة الرياض"><i class="bi bi-printer-fill"></i></a>`;
+    }
+    tr.innerHTML = `<td>${links}</td><td>${r.PersonName}</td><td>${r.SupplierName || ''}</td><td>${r.dbIndex}</td><td>${statusCell}</td><td>${createActionButtons(r, r.dbIndex)}</td>`;
     tbody.appendChild(tr);
   });
   const tooltips = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));


### PR DESCRIPTION
## Summary
- return `document_id` from search API results
- show default print link and extra Riyadh print link for `document_id` 4

## Testing
- `node -c backend/app.js`
- `node -c public/scripts/main.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae09889dec8331863337cc0bc7d1a0