### PR TITLE
Add Riyadh print URL configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DB3_ryadh_PRINT_URL=https://cert.mthali.com/pdf/ryadh/cert?code=

--- a/backend/app.js
+++ b/backend/app.js
@@ -180,7 +180,8 @@ app.post('/api/search', async (req, res) => {
           ...row,
           document_id: row.document_id,
           printUrl: dbConfigs[i].printUrl,
-          editUrl: dbConfigs[i].editUrl
+          editUrl: dbConfigs[i].editUrl,
+          ryadhPrintUrl: dbConfigs[i].ryadhPrintUrl
         })
       );
     } catch (err) {

--- a/backend/db.js
+++ b/backend/db.js
@@ -28,11 +28,12 @@ const dbConfigs = [
     user: process.env.DB3_USER,
     password: process.env.DB3_PASSWORD,
     printUrl: process.env.DB3_PRINT_URL,
-    editUrl: process.env.DB3_EDIT_URL
+    editUrl: process.env.DB3_EDIT_URL,
+    ryadhPrintUrl: process.env.DB3_ryadh_PRINT_URL
   }
 ];
 
-const pools = dbConfigs.map(({ printUrl, editUrl, ...cfg }) =>
+const pools = dbConfigs.map(({ printUrl, editUrl, ryadhPrintUrl, ...cfg }) =>
   mysql.createPool({
     ...cfg,
     charset: 'utf8mb4',

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -51,13 +51,11 @@ function renderPage(page) {
     const tr = document.createElement('tr');
     tr.dataset.index = r.dbIndex;
     const statusCell = `<span class="${statusClass(r.status)}">${statusText(r.status)}</span>`;
-    let defaultLink = `${r.printUrl}${r.Code}`;
+    let baseUrl = r.printUrl;
+    if (r.document_id == 4 && r.ryadhPrintUrl) baseUrl = r.ryadhPrintUrl;
+    let defaultLink = `${baseUrl}${r.Code}`;
     if (!defaultLink.includes('view=')) defaultLink += '&view=1';
     let links = `<a href="${defaultLink}" target="_blank"><pre class="codebox">${r.CertificateNumber}</pre></a>`;
-    if (r.document_id == 4) {
-      const riyadhLink = `${r.printUrl}${r.Code}&view=4`;
-      links += ` <a href="${riyadhLink}" target="_blank" title="طباعة أمانة الرياض"><i class="bi bi-printer-fill"></i></a>`;
-    }
     tr.innerHTML = `<td>${links}</td><td>${r.PersonName}</td><td>${r.SupplierName || ''}</td><td>${r.dbIndex}</td><td>${statusCell}</td><td>${createActionButtons(r, r.dbIndex)}</td>`;
     tbody.appendChild(tr);
   });


### PR DESCRIPTION
## Summary
- add `DB3_ryadh_PRINT_URL` to environment configuration
- include Riyadh print URL in DB settings and search responses
- switch frontend to use Riyadh print URL when `document_id` is 4

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae0d6d3d5c83318d821c7ee82e797e