### PR TITLE
Add Riyadh print URL handling for DB3

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DB3_ryadh_PRINT_URL=https://cert.mthali.com/pdf/ryadh/cert?code=

--- a/backend/app.js
+++ b/backend/app.js
@@ -113,7 +113,7 @@ app.post('/api/search', async (req, res) => {
     const pool = pools[i];
     try {
       let sql = `SELECT hc.certificateNumber AS CertificateNumber, hc.code AS Code, p.name AS PersonName,
-                 s.name AS SupplierName, ${i + 1} AS dbIndex, hc.status, p.id AS PersonId
+                 s.name AS SupplierName, ${i + 1} AS dbIndex, hc.status, p.id AS PersonId, hc.document_id AS document_id
                  FROM HC_HealthCertificate hc
                  LEFT JOIN HC_Person p ON hc.Person = p.id
                  LEFT JOIN HC_Facility f ON hc.Facility = f.id
@@ -179,7 +179,8 @@ app.post('/api/search', async (req, res) => {
         results.push({
           ...row,
           printUrl: dbConfigs[i].printUrl,
-          editUrl: dbConfigs[i].editUrl
+          editUrl: dbConfigs[i].editUrl,
+          ryadhPrintUrl: dbConfigs[i].ryadhPrintUrl
         })
       );
     } catch (err) {

--- a/backend/db.js
+++ b/backend/db.js
@@ -28,11 +28,12 @@ const dbConfigs = [
     user: process.env.DB3_USER,
     password: process.env.DB3_PASSWORD,
     printUrl: process.env.DB3_PRINT_URL,
-    editUrl: process.env.DB3_EDIT_URL
+    editUrl: process.env.DB3_EDIT_URL,
+    ryadhPrintUrl: process.env.DB3_ryadh_PRINT_URL
   }
 ];
 
-const pools = dbConfigs.map(({ printUrl, editUrl, ...cfg }) =>
+const pools = dbConfigs.map(({ printUrl, editUrl, ryadhPrintUrl, ...cfg }) =>
   mysql.createPool({
     ...cfg,
     charset: 'utf8mb4',

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -52,7 +52,11 @@ function renderPage(page) {
     tr.dataset.index = r.dbIndex;
     r.suffixurl = '&view=1';
     const statusCell = `<span class="${statusClass(r.status)}">${statusText(r.status)}</span>`;
-    const link = `${r.printUrl}${r.Code}`;
+    let baseUrl = r.printUrl;
+    if (r.document_id == 4 && r.ryadhPrintUrl) {
+      baseUrl = r.ryadhPrintUrl;
+    }
+    const link = `${baseUrl}${r.Code}`;
     tr.innerHTML = `<td><a href="${link}" target="_blank"><pre class="codebox">${r.CertificateNumber}</pre></a></td><td>${r.PersonName}</td><td>${r.SupplierName || ''}</td><td>${r.dbIndex}</td><td>${statusCell}</td><td>${createActionButtons(r, r.dbIndex)}</td>`;
     tbody.appendChild(tr);
   });


### PR DESCRIPTION
## Summary
- Add `DB3_ryadh_PRINT_URL` env variable
- Load and forward Riyadh print URL through backend
- Switch print link to Riyadh URL when `document_id` is 4

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae233317a883318125880f1c34b6c2