### PR TITLE
feat: validate DB1 env config

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -33,6 +33,22 @@ const dbConfigs = [
   }
 ];
 
+function validateDB1Config() {
+  const required = ['DB1_HOST', 'DB1_DATABASE', 'DB1_USER', 'DB1_PASSWORD'];
+  const missing = required.filter((key) => !process.env[key]);
+  if (missing.length) {
+    console.warn(
+      `Missing DB1 env variables: ${missing.join(', ')}. Skipping DB1 pool.`
+    );
+    return false;
+  }
+  return true;
+}
+
+if (!validateDB1Config()) {
+  dbConfigs.shift();
+}
+
 const pools = dbConfigs.map(({ printUrl, editUrl, ryadhPrintUrl, ...cfg }) =>
   mysql.createPool({
     ...cfg,

--- a/backend/db.test.js
+++ b/backend/db.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+// Stub mysql.createPool before requiring the module
+const mysql = require('mysql2/promise');
+mysql.createPool = () => ({ query: async () => {} });
+
+test('skips DB1 pool and warns when DB1 env vars are missing', async () => {
+  const originalEnv = { ...process.env };
+  delete process.env.DB1_HOST;
+  delete process.env.DB1_DATABASE;
+  delete process.env.DB1_USER;
+  delete process.env.DB1_PASSWORD;
+
+  let warning;
+  const originalWarn = console.warn;
+  console.warn = (msg) => {
+    warning = msg;
+  };
+
+  delete require.cache[require.resolve('./db.js')];
+  const { pools } = require('./db.js');
+
+  console.warn = originalWarn;
+  Object.assign(process.env, originalEnv);
+
+  assert.strictEqual(pools.length, 2);
+  assert.ok(warning.includes('Missing DB1 env variables'));
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node backend/app.js"
+    "start": "node backend/app.js",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- validate presence of required DB1 env vars before creating pools
- add tests to confirm DB1 pool is skipped when env vars are missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af70d7b7e88331a295a23b8c59d05e